### PR TITLE
Fix add adding invalid class name; Fix remove not removing class name

### DIFF
--- a/src/main/java/com/shrug/shrugUML/ShrugUMLClass.java
+++ b/src/main/java/com/shrug/shrugUML/ShrugUMLClass.java
@@ -8,36 +8,36 @@ package shrugUML;
 
 public class ShrugUMLClass
 {
-    // Default Ctor - sets the className to null
+    // Default Ctor - sets the m_className to null
     public ShrugUMLClass ()
     {
-	this.className = null;
+	m_className = null;
     }
-    // Name Ctor - sets className to newName
+    // Name Ctor - sets m_className to newName
     public ShrugUMLClass (String newName)
     {
-	this.className = newName;
+	m_className = newName;
     }
     // Public Methods
 
     /*
       Function: getName ()
-      Precondition: this has an initialized className
-      Postcondition: this.className is returned
+      Precondition: this has an initialized m_className
+      Postcondition: this.m_className is returned
      */
     public String getName ()
     {
-	return this.className;
+	return m_className;
     }
     /*
       Function: setName ()
       Precondition: newName is a valid string
-      Postcondition: this.className is set to newName
+      Postcondition: this.m_className is set to newName
      */
     public void setName (String newName)
     {
-	this.className = newName;
+	m_className = newName;
     }
     // Private Data Members
-    private String className;
+    private String m_className;
 }

--- a/src/main/java/com/shrug/shrugUML/ShrugUMLDiagram.java
+++ b/src/main/java/com/shrug/shrugUML/ShrugUMLDiagram.java
@@ -94,7 +94,7 @@ public class ShrugUMLDiagram
     public boolean nameInDiagram (String className)
     {
 	for (ShrugUMLClass classElement : m_classes)
-	    if (className == classElement.getName ())
+	    if (className.contentEquals (classElement.getName ()))
 		return true;
 	return false;
     }
@@ -108,8 +108,12 @@ public class ShrugUMLDiagram
     public ShrugUMLClass findClass (String className)
     {
 	for (ShrugUMLClass classElement : m_classes)
-	    if (className == classElement.getName ())
-		return classElement;
+	    {
+		if (className.contentEquals (classElement.getName ()))
+		    {
+			return classElement;
+		    }
+	    }
 	return new ShrugUMLClass(className);
     }
 


### PR DESCRIPTION
findClass () and findInDiagram were not working properly. Fixed to use String.contentEquals () instead of operator==, which doesn't work.  Now add and remove work as intended.