### PR TITLE
Update README with jar-with-dependencies classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 2. run `mvn package` to compile
 
 #### Running:
-1. run `java -cp target/uml-VERSION.jar Repl`
+1. run `java -cp target/uml-VERSION-jar-with-dependencies.jar Repl`


### PR DESCRIPTION
Update README to use `java -cp target/uml-VERSION-jar-with-dependencies.jar Repl`after adding maven-assembly-plugin for the Jackson-databind library