### PR TITLE
add addClass to controller that takes a shrugUMLClass

### DIFF
--- a/src/main/java/com/shrug/Controller/Controller.java
+++ b/src/main/java/com/shrug/Controller/Controller.java
@@ -45,6 +45,14 @@ public class Controller {
   }
 
   /*
+   *
+   *
+   */
+  public boolean addClass(ShrugUMLClass c) {
+    return m_diagram.addClass(className);
+  }
+
+  /*
    * Method: remove (String className)
    * Precondition: className is the name of the class to be removed from the
    * diagram


### PR DESCRIPTION
Controller needed this addClass because listeners in the GUI need the specific object added.  Check out method JGraphXAdapter.vertexAdded() and org.jgrapht.event.GraphVertexChangeEvent. There will eventually need to be one for relationships too. 