### PR TITLE
Model listenable graph

### DIFF
--- a/src/main/java/com/shrug/Controller/Controller.java
+++ b/src/main/java/com/shrug/Controller/Controller.java
@@ -10,8 +10,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.*;
+import org.jgrapht.ListenableGraph;
 import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultListenableGraph;
 import org.jgrapht.graph.SimpleDirectedGraph;
 import org.jgrapht.nio.Attribute;
 import org.jgrapht.nio.AttributeType;
@@ -197,8 +199,13 @@ public class Controller {
 
       JSONImporter<ShrugUMLClass, DefaultEdge> creator =
           new JSONImporter<ShrugUMLClass, DefaultEdge>();
-      SimpleDirectedGraph<ShrugUMLClass, DefaultEdge> g =
-          new SimpleDirectedGraph<ShrugUMLClass, DefaultEdge>(DefaultEdge.class);
+      ListenableGraph<ShrugUMLClass, DefaultEdge> g =
+          new DefaultListenableGraph<ShrugUMLClass, DefaultEdge>(
+              new SimpleDirectedGraph(DefaultEdge.class) {
+                {
+                  setVertexSupplier(() -> new ShrugUMLClass());
+                }
+              });
 
       BiConsumer<Pair<ShrugUMLClass, String>, Attribute> vertexConsumer =
           (pair, attr) -> {
@@ -233,7 +240,6 @@ public class Controller {
           };
 
       creator.addVertexAttributeConsumer(vertexConsumer);
-      g.setVertexSupplier(() -> new ShrugUMLClass());
       creator.importGraph(g, r);
       m_diagram.setGraph(g);
       return true;
@@ -246,7 +252,7 @@ public class Controller {
    * Precondition: this is instantiated
    * Postcondition: the underlying graph is returned
    */
-  public SimpleDirectedGraph<ShrugUMLClass, DefaultEdge> getGraph() {
+  public ListenableGraph<ShrugUMLClass, DefaultEdge> getGraph() {
     return m_diagram.getGraph();
   }
 

--- a/src/main/java/com/shrug/GUI/GUI.java
+++ b/src/main/java/com/shrug/GUI/GUI.java
@@ -144,9 +144,6 @@ public class GUI {
       String name = getInputDialogBox("Add", "Add a class", "Enter a class name:");
       ShrugUMLClass add = new ShrugUMLClass(name);
       control.addClass(add);
-      jgxAdapter.vertexAdded(
-          new GraphVertexChangeEvent<ShrugUMLClass>(
-              control.getGraph(), GraphVertexChangeEvent.VERTEX_ADDED, add));
       layout.execute(jgxAdapter.getDefaultParent());
       jgxAdapter.repaint();
       content.revalidate();
@@ -165,9 +162,6 @@ public class GUI {
       String name = getInputDialogBox("Remove", "Remove a class", "Enter a class name:");
       ShrugUMLClass remove = control.getDiagram().findClass(name);
       control.removeClass(name);
-      jgxAdapter.vertexRemoved(
-          new GraphVertexChangeEvent<ShrugUMLClass>(
-              control.getGraph(), GraphVertexChangeEvent.VERTEX_REMOVED, remove));
       layout.execute(jgxAdapter.getDefaultParent());
       jgxAdapter.repaint();
       content.revalidate();
@@ -249,15 +243,6 @@ public class GUI {
               "Enter destination classes separated by whitespace:");
       ArrayList<String> destL = new ArrayList<String>(Arrays.asList(dest.trim().split("\\s+")));
       control.addRelationships(src, destL);
-      for (String className : destL) {
-        jgxAdapter.edgeAdded(
-            new GraphEdgeChangeEvent<ShrugUMLClass, DefaultEdge>(
-                control.getGraph(),
-                GraphEdgeChangeEvent.EDGE_ADDED,
-                control.getDiagram().getRelationship(src, className),
-                control.getDiagram().findClass(src),
-                control.getDiagram().findClass(className)));
-      }
       layout.execute(jgxAdapter.getDefaultParent());
       jgxAdapter.repaint();
       content.revalidate();
@@ -276,15 +261,6 @@ public class GUI {
               "Remove a relation",
               "Enter destination classes separated by whitespace:");
       ArrayList<String> destL = new ArrayList<String>(Arrays.asList(dest.trim().split("\\s+")));
-      for (String className : destL) {
-        jgxAdapter.edgeRemoved(
-            new GraphEdgeChangeEvent<ShrugUMLClass, DefaultEdge>(
-                control.getGraph(),
-                GraphEdgeChangeEvent.BEFORE_EDGE_REMOVED,
-                control.getDiagram().getRelationship(src, className),
-                control.getDiagram().findClass(src),
-                control.getDiagram().findClass(className)));
-      }
       control.removeRelationships(src, destL);
       layout.execute(jgxAdapter.getDefaultParent());
       jgxAdapter.repaint();

--- a/src/main/java/com/shrug/shrugUML/ShrugUMLDiagram.java
+++ b/src/main/java/com/shrug/shrugUML/ShrugUMLDiagram.java
@@ -7,13 +7,18 @@ package shrugUML;
 
 // Includes
 import java.util.Set;
+import org.jgrapht.ListenableGraph;
 import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultListenableGraph;
 import org.jgrapht.graph.SimpleDirectedGraph;
 
 public class ShrugUMLDiagram {
   // Default Ctor - new Diagram with nothing in it
   public ShrugUMLDiagram() {
-    m_diagram = new SimpleDirectedGraph<ShrugUMLClass, DefaultEdge>(DefaultEdge.class);
+    SimpleDirectedGraph<ShrugUMLClass, DefaultEdge> simpleGraph =
+        new SimpleDirectedGraph<ShrugUMLClass, DefaultEdge>(DefaultEdge.class);
+    simpleGraph.setVertexSupplier(() -> new ShrugUMLClass());
+    m_diagram = new DefaultListenableGraph<ShrugUMLClass, DefaultEdge>(simpleGraph);
   }
 
   /** *********************************************************************** */
@@ -160,11 +165,11 @@ public class ShrugUMLDiagram {
 
   /** *********************************************************************** */
   // Utility Methods
-  public SimpleDirectedGraph<ShrugUMLClass, DefaultEdge> getGraph() {
+  public ListenableGraph<ShrugUMLClass, DefaultEdge> getGraph() {
     return m_diagram;
   }
 
-  public void setGraph(SimpleDirectedGraph<ShrugUMLClass, DefaultEdge> graph) {
+  public void setGraph(ListenableGraph<ShrugUMLClass, DefaultEdge> graph) {
     m_diagram = graph;
   }
 
@@ -173,5 +178,5 @@ public class ShrugUMLDiagram {
 
   /** *********************************************************************** */
   // Private Data Members
-  private SimpleDirectedGraph<ShrugUMLClass, DefaultEdge> m_diagram;
+  private ListenableGraph<ShrugUMLClass, DefaultEdge> m_diagram;
 }


### PR DESCRIPTION
## Pull Request

### Related Task or Issue

Migrate Model to Listenable Graph

### Describe the change

Changes the underlying model to be a `ListenableGraph` that uses a `SimpleDirectedGraph`. Check out the constructor in `ShrugUMLDiagram.java` to see.  The ListenableGraph removes the need for change events in the GUI (I guess they come built in with the adapter??), so those are also removed. In Controller's `load()`, the Graph that is loaded is constructed with a VertexSuppler, since a ListenableGraph can't have a setVertexSupplier. 

### Authors

Meireg and Cole

### Time

45 Minutes
