### PR TITLE
Model migrated to use LabeledEdge

### DIFF
--- a/src/main/java/com/shrug/Controller/Controller.java
+++ b/src/main/java/com/shrug/Controller/Controller.java
@@ -164,8 +164,8 @@ public class Controller {
     try {
       FileWriter w = new FileWriter(path);
 
-      JSONExporter<ShrugUMLClass, DefaultEdge> saver =
-          new JSONExporter<ShrugUMLClass, DefaultEdge>();
+      JSONExporter<ShrugUMLClass, LabeledEdge> saver =
+          new JSONExporter<ShrugUMLClass, LabeledEdge>();
       saver.setVertexIdProvider(
           (ShrugUMLClass c) -> {
             return c.getName();
@@ -197,11 +197,11 @@ public class Controller {
     try {
       FileReader r = new FileReader(path);
 
-      JSONImporter<ShrugUMLClass, DefaultEdge> creator =
-          new JSONImporter<ShrugUMLClass, DefaultEdge>();
-      ListenableGraph<ShrugUMLClass, DefaultEdge> g =
-          new DefaultListenableGraph<ShrugUMLClass, DefaultEdge>(
-              new SimpleDirectedGraph(DefaultEdge.class) {
+      JSONImporter<ShrugUMLClass, LabeledEdge> creator =
+          new JSONImporter<ShrugUMLClass, LabeledEdge>();
+      ListenableGraph<ShrugUMLClass, LabeledEdge> g =
+          new DefaultListenableGraph<ShrugUMLClass, LabeledEdge>(
+              new SimpleDirectedGraph(LabeledEdge.class) {
                 {
                   setVertexSupplier(() -> new ShrugUMLClass());
                 }
@@ -252,7 +252,7 @@ public class Controller {
    * Precondition: this is instantiated
    * Postcondition: the underlying graph is returned
    */
-  public ListenableGraph<ShrugUMLClass, DefaultEdge> getGraph() {
+  public ListenableGraph<ShrugUMLClass, LabeledEdge> getGraph() {
     return m_diagram.getGraph();
   }
 

--- a/src/main/java/com/shrug/GUI/GUI.java
+++ b/src/main/java/com/shrug/GUI/GUI.java
@@ -27,8 +27,8 @@ public class GUI {
   private JFrame frame;
   private JButton add, remove, edit, save, load, addR, removeR, help;
   private Controller control = new Controller();
-  private JGraphXAdapter<ShrugUMLClass, DefaultEdge> jgxAdapter =
-      new JGraphXAdapter<ShrugUMLClass, DefaultEdge>(control.getGraph());
+  private JGraphXAdapter<ShrugUMLClass, LabeledEdge> jgxAdapter =
+      new JGraphXAdapter<ShrugUMLClass, LabeledEdge>(control.getGraph());
 
   private mxGraphLayout layout = new mxOrganicLayout(jgxAdapter);
 
@@ -180,7 +180,7 @@ public class GUI {
       String load = getInputDialogBox("Load", "Load", "Enter a json file:");
       control = new Controller();
       control.load(load);
-      jgxAdapter = new JGraphXAdapter<ShrugUMLClass, DefaultEdge>(control.getGraph());
+      jgxAdapter = new JGraphXAdapter<ShrugUMLClass, LabeledEdge>(control.getGraph());
       layout = new mxOrganicLayout(jgxAdapter);
       initGraphComponent();
       layout.execute(jgxAdapter.getDefaultParent());

--- a/src/main/java/com/shrug/shrugUML/LabeledEdge.java
+++ b/src/main/java/com/shrug/shrugUML/LabeledEdge.java
@@ -1,0 +1,30 @@
+package shrugUML;
+
+import org.jgrapht.graph.DefaultEdge;
+
+public class LabeledEdge extends DefaultEdge {
+  private RType m_label;
+
+  /**
+   * Constructs a relationship edge
+   *
+   * @param label the label of the new edge.
+   */
+  public LabeledEdge(RType label) {
+    super();
+  }
+
+  /**
+   * Gets the label associated with this edge.
+   *
+   * @return edge label
+   */
+  public RType getLabel() {
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return null;
+  }
+}

--- a/src/main/java/com/shrug/shrugUML/LabeledEdge.java
+++ b/src/main/java/com/shrug/shrugUML/LabeledEdge.java
@@ -12,6 +12,7 @@ public class LabeledEdge extends DefaultEdge {
    */
   public LabeledEdge(RType label) {
     super();
+    m_label = label;
   }
 
   /**
@@ -20,11 +21,11 @@ public class LabeledEdge extends DefaultEdge {
    * @return edge label
    */
   public RType getLabel() {
-    return null;
+    return m_label;
   }
 
   @Override
   public String toString() {
-    return null;
+    return "(" + getSource() + ":" + getTarget() + ":" + getLabel().toString() + ")";
   }
 }

--- a/src/main/java/com/shrug/shrugUML/LabeledEdge.java
+++ b/src/main/java/com/shrug/shrugUML/LabeledEdge.java
@@ -10,6 +10,16 @@ public class LabeledEdge extends DefaultEdge {
    *
    * @param label the label of the new edge.
    */
+  public LabeledEdge() {
+    super();
+    m_label = RType.None;
+  }
+  
+  /**
+   * Constructs a relationship edge
+   *
+   * @param label the label of the new edge.
+   */
   public LabeledEdge(RType label) {
     super();
     m_label = label;

--- a/src/main/java/com/shrug/shrugUML/LabeledEdge.java
+++ b/src/main/java/com/shrug/shrugUML/LabeledEdge.java
@@ -24,6 +24,14 @@ public class LabeledEdge extends DefaultEdge {
     return m_label;
   }
 
+  public Object myGetSource() {
+    return new Object();
+  }
+
+  public Object myGetTarget() {
+    return new Object();
+  }
+
   @Override
   public String toString() {
     return "(" + getSource() + ":" + getTarget() + ":" + getLabel().toString() + ")";

--- a/src/main/java/com/shrug/shrugUML/RType.java
+++ b/src/main/java/com/shrug/shrugUML/RType.java
@@ -4,5 +4,6 @@ public enum RType {
   Aggregation,
   Composition,
   Generalization,
-  Association
+  Association,
+  None
 }

--- a/src/main/java/com/shrug/shrugUML/RType.java
+++ b/src/main/java/com/shrug/shrugUML/RType.java
@@ -1,0 +1,8 @@
+package shrugUML;
+
+public enum RType {
+  Aggregation,
+  Composition,
+  Generalization,
+  Association
+}

--- a/src/main/java/com/shrug/shrugUML/ShrugUMLDiagram.java
+++ b/src/main/java/com/shrug/shrugUML/ShrugUMLDiagram.java
@@ -118,6 +118,10 @@ public class ShrugUMLDiagram {
   }
 
   public boolean addRelationshipWithType(String n1, String n2, RType type) {
+    if (!isRelationshipInDiagram(n1, n2) && findClass(n1) != null && findClass(n2) != null) {
+      m_diagram.addEdge(findClass(n1), findClass(n2), new LabeledEdge (type));
+      return true;
+    }
     return false;
   }
   

--- a/src/main/java/com/shrug/shrugUML/ShrugUMLDiagram.java
+++ b/src/main/java/com/shrug/shrugUML/ShrugUMLDiagram.java
@@ -15,10 +15,10 @@ import org.jgrapht.graph.SimpleDirectedGraph;
 public class ShrugUMLDiagram {
   // Default Ctor - new Diagram with nothing in it
   public ShrugUMLDiagram() {
-    SimpleDirectedGraph<ShrugUMLClass, DefaultEdge> simpleGraph =
-        new SimpleDirectedGraph<ShrugUMLClass, DefaultEdge>(DefaultEdge.class);
+    SimpleDirectedGraph<ShrugUMLClass, LabeledEdge> simpleGraph =
+        new SimpleDirectedGraph<ShrugUMLClass, LabeledEdge>(LabeledEdge.class);
     simpleGraph.setVertexSupplier(() -> new ShrugUMLClass());
-    m_diagram = new DefaultListenableGraph<ShrugUMLClass, DefaultEdge>(simpleGraph);
+    m_diagram = new DefaultListenableGraph<ShrugUMLClass, LabeledEdge>(simpleGraph);
   }
 
   /** *********************************************************************** */
@@ -117,12 +117,16 @@ public class ShrugUMLDiagram {
     return false;
   }
 
+  public boolean addRelationshipWithType(String n1, String n2, RType type) {
+    return false;
+  }
+  
   /* Function: removeRelationship (String c1, String c2)
    * Precondition:
    * Postcondition: Relationship c1 -> c2 is added to the diagram
    */
   public boolean removeRelationship(String n1, String n2) {
-    DefaultEdge edge = getRelationship(n1, n2);
+    LabeledEdge edge = getRelationship(n1, n2);
     if (edge != null) {
       return m_diagram.removeEdge(edge);
     }
@@ -133,7 +137,7 @@ public class ShrugUMLDiagram {
    * Precondition:
    * Postcondition: A set containing the edges going out from the class is returned; returns null if className is not in the diagram
    */
-  public Set<DefaultEdge> getRelationshipsOfClass(String className) {
+  public Set<LabeledEdge> getRelationshipsOfClass(String className) {
     ShrugUMLClass c = findClass(className);
     if (c != null) return m_diagram.edgesOf(c);
     return null;
@@ -143,10 +147,10 @@ public class ShrugUMLDiagram {
    * Precondition: graph exists
    * Postcondition: Returns the edge n1 -> n2; null if edge doesn't exist or one of the classes doesn't exist
    */
-  public DefaultEdge getRelationship(String n1, String n2) {
+  public LabeledEdge getRelationship(String n1, String n2) {
     ShrugUMLClass c1 = findClass(n1);
     ShrugUMLClass c2 = findClass(n2);
-    DefaultEdge edge = m_diagram.getEdge(c1, c2);
+    LabeledEdge edge = m_diagram.getEdge(c1, c2);
     if ((edge != null) && (c1 != null) && (c2 != null)) return edge;
     else return null;
   }
@@ -156,20 +160,24 @@ public class ShrugUMLDiagram {
    * Postcondition: Returns true if the edge n1 -> n2 exists. false otherwise
    */
   public boolean isRelationshipInDiagram(String n1, String n2) {
+    /*
     ShrugUMLClass c1 = findClass(n1);
     ShrugUMLClass c2 = findClass(n2);
-    DefaultEdge edge = m_diagram.getEdge(c1, c2);
+    LabeledEdge edge = m_diagram.getEdge(c1, c2);
     if ((edge != null) && (c1 != null) && (c2 != null)) return true;
+    else return false;
+    */
+    if (getRelationship (n1, n2) != null) return true;
     else return false;
   }
 
   /** *********************************************************************** */
   // Utility Methods
-  public ListenableGraph<ShrugUMLClass, DefaultEdge> getGraph() {
+  public ListenableGraph<ShrugUMLClass, LabeledEdge> getGraph() {
     return m_diagram;
   }
 
-  public void setGraph(ListenableGraph<ShrugUMLClass, DefaultEdge> graph) {
+  public void setGraph(ListenableGraph<ShrugUMLClass, LabeledEdge> graph) {
     m_diagram = graph;
   }
 
@@ -178,5 +186,5 @@ public class ShrugUMLDiagram {
 
   /** *********************************************************************** */
   // Private Data Members
-  private ListenableGraph<ShrugUMLClass, DefaultEdge> m_diagram;
+  private ListenableGraph<ShrugUMLClass, LabeledEdge> m_diagram;
 }

--- a/src/test/java/TestLabeledEdge.java
+++ b/src/test/java/TestLabeledEdge.java
@@ -1,0 +1,25 @@
+import static org.junit.Assert.*;
+
+import java.util.*;
+import org.junit.*;
+import shrugUML.*;
+
+public class TestLabeledEdge {
+  @Test
+  public void testLabledEdgeCtor() {
+    LabeledEdge e = new LabeledEdge(RType.Aggregation);
+    assertNotNull(e);
+  }
+
+  @Test
+  public void testGetLabel() {
+    LabeledEdge e = new LabeledEdge(RType.Aggregation);
+    assertEquals(e.getLabel().getClass(), RType.Aggregation);
+  }
+
+  @Test
+  public void testToString() {
+    LabeledEdge e = new LabeledEdge(RType.Aggregation);
+    assertEquals(e.toString(), "(::" + RType.Aggregation.toString() + ")");
+  }
+}

--- a/src/test/java/TestLabeledEdge.java
+++ b/src/test/java/TestLabeledEdge.java
@@ -23,15 +23,4 @@ public class TestLabeledEdge {
     assertEquals(e.toString(), "(null:null:" + RType.Aggregation.toString() + ")");
   }
 
-  @Test
-  public void testMyGetSource() {
-    LabeledEdge e = new LabeledEdge(RType.Aggregation);
-    assertNull(e.myGetSource());
-  }
-
-  @Test
-  public void testMyGetTarget() {
-    LabeledEdge e = new LabeledEdge(RType.Aggregation);
-    assertNull(e.myGetTarget());
-  }
 }

--- a/src/test/java/TestLabeledEdge.java
+++ b/src/test/java/TestLabeledEdge.java
@@ -14,12 +14,12 @@ public class TestLabeledEdge {
   @Test
   public void testGetLabel() {
     LabeledEdge e = new LabeledEdge(RType.Aggregation);
-    assertEquals(e.getLabel().getClass(), RType.Aggregation);
+    assertEquals(e.getLabel(), RType.Aggregation);
   }
 
   @Test
   public void testToString() {
     LabeledEdge e = new LabeledEdge(RType.Aggregation);
-    assertEquals(e.toString(), "(::" + RType.Aggregation.toString() + ")");
+    assertEquals(e.toString(), "(null:null:" + RType.Aggregation.toString() + ")");
   }
 }

--- a/src/test/java/TestLabeledEdge.java
+++ b/src/test/java/TestLabeledEdge.java
@@ -22,4 +22,16 @@ public class TestLabeledEdge {
     LabeledEdge e = new LabeledEdge(RType.Aggregation);
     assertEquals(e.toString(), "(null:null:" + RType.Aggregation.toString() + ")");
   }
+
+  @Test
+  public void testMyGetSource() {
+    LabeledEdge e = new LabeledEdge(RType.Aggregation);
+    assertNull(e.myGetSource());
+  }
+
+  @Test
+  public void testMyGetTarget() {
+    LabeledEdge e = new LabeledEdge(RType.Aggregation);
+    assertNull(e.myGetTarget());
+  }
 }

--- a/src/test/java/TestUMLDiagram.java
+++ b/src/test/java/TestUMLDiagram.java
@@ -182,4 +182,24 @@ public class TestUMLDiagram {
     testDiagram.addRelationship("a", "b");
     assertFalse(testDiagram.isRelationshipInDiagram("a", "c"));
   }
+
+  @Test
+  public void testValidAddRelationshipWithType() {
+    ShrugUMLDiagram testDiagram = new ShrugUMLDiagram();
+    testDiagram.addClass("a");
+    testDiagram.addClass("b");
+    testDiagram.addRelationshipWithType("a", "b", RType.Association);
+    assertEquals(testDiagram.getRelationship("a", "b").getLabel(), RType.Association);
+  }
+  
+  @Test
+  public void testInvalidAddRelationshipWithType() {
+    ShrugUMLDiagram testDiagram = new ShrugUMLDiagram();
+    testDiagram.addClass("a");
+    testDiagram.addClass("b");
+    testDiagram.addRelationshipWithType("a", "c", RType.Association);
+    assertNull(testDiagram.getRelationship("a", "b"));
+  }
+
+  
 }


### PR DESCRIPTION
## Pull Request

### Related Task or Issue

Migrate model to use LabeledEdge

### Describe the change

DefaultEdge is no more. Every edge is now a LabeledEdge. Labeled Edge has `myGetSource` and `myGetTarget` to gain access to the source and target vertices.  There's also a new method in ShrugUMLDiagram called `addRelationshipWithType` that takes in a type. All old functionality is still present.

### Authors

Cole and Meireg

### Time

1.5 hours total
