### PR TITLE
Gui printing

### DIFF
--- a/src/main/java/com/shrug/Controller/Controller.java
+++ b/src/main/java/com/shrug/Controller/Controller.java
@@ -71,7 +71,7 @@ public class Controller {
             Map<String, Attribute> map = new HashMap<String, Attribute>();
             map.put("Name", new DefaultAttribute(c.getName(), AttributeType.STRING));
             map.put("Attributes", new DefaultAttribute(c.getAttributes(), AttributeType.UNKNOWN));
-            map.put("Methods", new DefaultAttribute(c.getMethods(), AttributeType.UNKNOWN));
+            map.put("Methods", new DefaultAttribute(c.getMethods().toString().replace("),", ");"), AttributeType.UNKNOWN));
             return map;
           });
       saver.exportGraph(getGraph(), w);
@@ -105,66 +105,71 @@ public class Controller {
 
       BiConsumer<Pair<ShrugUMLClass, String>, Attribute> vertexConsumer =
           (pair, attr) -> {
-            switch (pair.getSecond()) {
-              case "Name":
-                {
-                  pair.getFirst().setName(attr.getValue());
-                  break;
-                }
-              case "Attributes":
-                {
-                  ArrayList<String> attributes =
-                      new ArrayList<String>(
-                          Arrays.asList(
-                              attr.getValue()
-                                  .trim()
-                                  .replace(",", "")
-                                  .replace("[", "")
-                                  .replace("]", "")
-                                  .split("\\s+")));
-                  pair.getFirst().addAttributes(attributes);
-                  break;
-                }
-              case "Methods":
-                {
-                  ArrayList<String> methods =
-                      new ArrayList<String>(Arrays.asList(attr.getValue().trim().split(", ")));
-                  pair.getFirst().addMethods(methods);
-                  break;
-                }
-            }
-          };
+        switch (pair.getSecond()) {
+          case "Name":
+          {
+            pair.getFirst().setName(attr.getValue());
+            break;
+          }
+          case "Attributes":
+          {
+            ArrayList<String> attributes =
+            new ArrayList<String>(
+                Arrays.asList(
+                    attr.getValue()
+                    .trim()
+                    .replace("[", "")
+                    .replace("]", "")
+                    .split("\\s*,\\s+")));
+            pair.getFirst().addAttributes(attributes);
+            break;
+          }
+          case "Methods":
+          {
+            
+            ArrayList<String> methods =
+            new ArrayList<String>(Arrays.asList(
+                attr.getValue()
+                .trim()
+                .replace("[", "")
+                .replace("]", "")
+                .split(";\\s+")));
+            pair.getFirst().addMethods(methods);
+            break;
+          }
+        }
+      };
 
       BiConsumer<Pair<LabeledEdge, String>, Attribute> edgeConsumer =
           (pair, attr) -> {
-            switch (attr.getValue()) {
-              case "Association":
-                {
-                  pair.getFirst().setLabel(RType.Association);
-                  break;
-                }
-              case "Generalization":
-                {
-                  pair.getFirst().setLabel(RType.Generalization);
-                  break;
-                }
-              case "Aggregation":
-                {
-                  pair.getFirst().setLabel(RType.Aggregation);
-                  break;
-                }
-              case "Composition":
-                {
-                  pair.getFirst().setLabel(RType.Composition);
-                  break;
-                }
-              case "None":
-                {
-                  pair.getFirst().setLabel(RType.None);
-                  break;
-                }
-            }
-          };
+        switch (attr.getValue()) {
+          case "Association":
+          {
+            pair.getFirst().setLabel(RType.Association);
+            break;
+          }
+          case "Generalization":
+          {
+            pair.getFirst().setLabel(RType.Generalization);
+            break;
+          }
+          case "Aggregation":
+          {
+            pair.getFirst().setLabel(RType.Aggregation);
+            break;
+          }
+          case "Composition":
+          {
+            pair.getFirst().setLabel(RType.Composition);
+            break;
+          }
+          case "None":
+          {
+            pair.getFirst().setLabel(RType.None);
+            break;
+          }
+        }
+      };
 
       creator.addEdgeAttributeConsumer(edgeConsumer);
       creator.addVertexAttributeConsumer(vertexConsumer);

--- a/src/main/java/com/shrug/GUI/GUI.java
+++ b/src/main/java/com/shrug/GUI/GUI.java
@@ -105,6 +105,8 @@ public class GUI {
     if (graph != null) content.remove(graph);
     jgxAdapter.setAutoSizeCells(true);
     graph = new mxGraphComponent(jgxAdapter);
+    graph.setDragEnabled(false);
+    graph.setConnectable(false);
     content.add(graph, BorderLayout.CENTER);
     layout.execute(jgxAdapter.getDefaultParent());
   }

--- a/src/main/java/com/shrug/shrugUML/ShrugUMLClass.java
+++ b/src/main/java/com/shrug/shrugUML/ShrugUMLClass.java
@@ -117,11 +117,19 @@ public class ShrugUMLClass {
 
   @Override
   public String toString() {
+    String attributes = "";
+    for (String a : m_attributes) {
+      attributes += a + "\n";
+    }
+    String methods = "";
+    for (String m : m_methods) {
+      methods += m + "\n";
+    }
     return m_className 
         + "\n__________\n"
-        + m_attributes.toString().replace("[", "").replace("]", "").replace(",", "\n")
+        + attributes
         + "\n__________\n"
-        + m_methods.toString().replace("[", "").replace("]", "").replace(",", "\n");
+        + methods;
   }
 
   // Private Data Members


### PR DESCRIPTION
## Pull Request

### Related Task or Issue
gui printing
fake arrows being able to be drawn
save/load fix

### Describe the change
The `ShrugUMLClass.toString()` isn't a `.replace()` hack anymore.

save/load were fixed to work with methods, something that we overlooked.  Essentially I added a semicolon delimiter between methods when they're being saved, then I split on the semicolon when the json is loaded.

arrows can no longer be created at random in the GUI (rejoice).

### Authors

Cole

### Time

1 hour